### PR TITLE
Upgrade fontnik to v0.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   ],
   "dependencies": {
     "@mapbox/glyph-pbf-composite": "0.0.3",
-    "fontnik": "0.5.0"
+    "fontnik": "0.5.1"
   }
 }


### PR DESCRIPTION
* Add support for node v8:  
https://github.com/mapbox/node-fontnik/blob/master/CHANGELOG.md#051